### PR TITLE
Update PageFooter.js

### DIFF
--- a/client/src/layout/components/footer/PageFooter.js
+++ b/client/src/layout/components/footer/PageFooter.js
@@ -36,7 +36,7 @@ const PageFooter = () => (
               <List.Item as={Link} to='/tos'>Terms of Service</List.Item>
               <List.Item as={Link} to='/disclaimer'>Disclaimer</List.Item>
               <List.Item as={Link} to='/privacy'>Privacy Policy</List.Item>
-              <List.Item as='a'>Corporate Sponsors</List.Item>
+              <List.Item as='a'>Sponsors</List.Item>
             </List>
           </Grid.Column>
         </Grid.Row>


### PR DESCRIPTION
Nova asked me to change the "Corporate Sponsors" link in the Footer to just "Sponsors" in order to match the link in the Header